### PR TITLE
Change rails dependency from 3.2.16 to 4.0.0

### DIFF
--- a/google_web_fonts.gemspec
+++ b/google_web_fonts.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   #s.add_dependency "rails", "~> 4.0.2"
-  s.add_dependency "rails", "~> 3.2.16"
+  s.add_dependency "rails", "~> 4.0.0"
 
   s.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
Comme pour lerepo "system_pay", ou @fcarrega avait créé une branche 'rails_4', je fais une branche rails 4 pour la migration de 'arizuka-edge' vers rails 4
